### PR TITLE
drop support for PHP 8.4

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -12,11 +12,12 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   cleanup:
     name: "Cleanup Caches"
-    uses: "mimmi20/ci/.github/workflows/cleanup-cache.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/cleanup-cache.yml@8.5"
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
   validate-all:
     name: "Validate Project"
 
-    uses: "mimmi20/ci/.github/workflows/validate-all.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/validate-all.yml@8.5"
     with:
       skip-validate-yaml: false
       skip-validate-md: false
@@ -31,7 +31,7 @@ jobs:
   validate-php:
     name: "Validate PHP"
 
-    uses: "mimmi20/ci/.github/workflows/validate-php.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/validate-php.yml@8.5"
     with:
       extensions: "ctype, curl, dom, fileinfo, iconv, intl, mbstring, simplexml, tokenizer, xml, xmlwriter"
       ini-values: "opcache.enable=1, opcache.fast_shutdown=0, zend.assertions=1, assert.exception=On, intl.default_locale=de, intl.use_exceptions=1, zend.exception_ignore_args=0"
@@ -49,9 +49,9 @@ jobs:
       - "validate-all"
       - "validate-php"
 
-    uses: "mimmi20/ci/.github/workflows/install-php.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/install-php.yml@8.5"
     with:
-      extensions: "ctype, curl, dom, fileinfo, iconv, intl, mbstring, simplexml, tokenizer, xml, xmlwriter"
+      extensions: "ctype, curl, dom, fileinfo, iconv, mbstring, intl, simplexml, tokenizer, xml, xmlwriter"
       ini-values: "opcache.enable=1, opcache.fast_shutdown=0, zend.assertions=1, assert.exception=On, intl.default_locale=de, intl.use_exceptions=1, zend.exception_ignore_args=0"
       composer-options: "--optimize-autoloader --prefer-dist --prefer-stable -v"
       skip-librabbitmq-install: true
@@ -70,7 +70,7 @@ jobs:
 
     needs: "install"
 
-    uses: "mimmi20/ci/.github/workflows/analytics-php.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/analytics-php.yml@8.5"
     with:
       extensions: "ctype, curl, dom, fileinfo, iconv, intl, mbstring, simplexml, tokenizer, xml, xmlwriter"
       ini-values: "opcache.enable=1, opcache.fast_shutdown=0, zend.assertions=1, assert.exception=On, intl.default_locale=de, intl.use_exceptions=1, zend.exception_ignore_args=0"
@@ -87,7 +87,7 @@ jobs:
 
     needs: "analytics"
 
-    uses: "mimmi20/ci/.github/workflows/test-php.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/test-php.yml@8.5"
     with:
       extensions: "ctype, curl, dom, fileinfo, iconv, intl, mbstring, simplexml, tokenizer, xml, xmlwriter"
       ini-values: "opcache.enable=1, opcache.fast_shutdown=0, zend.assertions=1, assert.exception=On, intl.default_locale=de, intl.use_exceptions=1, zend.exception_ignore_args=0"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   dependency-review:
     name: "Review"
-    uses: "mimmi20/ci/.github/workflows/review-dependency.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/review-dependency.yml@8.5"
 
   # This is a meta job to avoid to have to constantly change the protection rules
   # whenever we touch the matrix.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     name: "Sync labels"
-    uses: "mimmi20/ci/.github/workflows/sync-labels.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/sync-labels.yml@8.5"
     with:
       repository: ${{ github.repository }}
       manifest: ".github/labels.yml"

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: "mimmi20/ci/.github/workflows/lint-actions.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/lint-actions.yml@8.5"
     with:
       skip-nasm-install: true
       skip-libimagequant-install: true

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   lock:
     name: "Lock Issues"
-    uses: "mimmi20/ci/.github/workflows/lock-issues.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/lock-issues.yml@8.5"
     permissions:
+      contents: read
       issues: write

--- a/.github/workflows/reactions.yml
+++ b/.github/workflows/reactions.yml
@@ -23,4 +23,4 @@ permissions:
 jobs:
   action:
     name: "Comments"
-    uses: "mimmi20/ci/.github/workflows/reaction-comments.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/reaction-comments.yml@8.5"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,4 +31,4 @@ jobs:
       # otherwise, read permission is required at least
       pull-requests: write
 
-    uses: "mimmi20/ci/.github/workflows/draft-release.yml@8.4"
+    uses: "mimmi20/ci/.github/workflows/draft-release.yml@8.5"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "source": "https://github.com/mimmi20/ua-device-type"
   },
   "require": {
-    "php": "~8.4.0 || ~8.5.0 || ~8.6.0",
+    "php": "~8.5.0 || ~8.6.0",
     "ext-mbstring": "*"
   },
   "require-dev": {
@@ -71,6 +71,7 @@
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
+      "ergebnis/composer-normalize": true,
       "infection/extension-installer": true,
       "phpstan/extension-installer": true
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
   level: max
 
-  phpVersion: 80400 # PHP 8.4
+  phpVersion: 80500 # PHP 8.5
 
   parallel:
     maximumNumberOfProcesses: 1

--- a/rector.php
+++ b/rector.php
@@ -15,7 +15,6 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php84\Rector\MethodCall\NewMethodCallWithoutParenthesesRector;
@@ -31,15 +30,14 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->sets([
         SetList::DEAD_CODE,
-        LevelSetList::UP_TO_PHP_84,
-        PHPUnitSetList::PHPUNIT_100,
+        LevelSetList::UP_TO_PHP_85,
+        PHPUnitSetList::PHPUNIT_120,
     ]);
 
     $rectorConfig->skip(
         [
             NullToStrictStringFuncCallArgRector::class,
             RemoveDeadInstanceOfRector::class,
-            FirstClassCallableRector::class,
             RemoveAlwaysTrueIfConditionRector::class,
             RemoveParentCallWithoutParentRector::class,
             NewMethodCallWithoutParenthesesRector::class,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * **PHP-Versionsanforderungen:** Support für PHP 8.4 wurde entfernt; Paket erfordert nun PHP 8.5 oder neuer, unterstützt auch PHP 8.6
  * Automatisierte CI/CD-Workflows auf GitHub Actions in der Version 8.5 aktualisiert, einschließlich Integration Tests, Dependency Review, Label Sync und Release Drafting
  * Entwicklungs-Konfigurationen für Linting, statische Analyse und Unit-Tests optimiert und auf neuere Versionen aktualisiert
  * Composer-Abhängigkeitsverwaltung konfiguriert

<!-- end of auto-generated comment: release notes by coderabbit.ai -->